### PR TITLE
Fix for us fogies on older OS Xen

### DIFF
--- a/objc/GIFs/GIF.m
+++ b/objc/GIFs/GIF.m
@@ -46,7 +46,7 @@
     if ([downloadURL hasPrefix:@"http://gifsound.com/?gif="]) {
         downloadURL = [downloadURL stringByReplacingOccurrencesOfString:@"http://gifsound.com/?gif=" withString:@""];
         downloadURL = [downloadURL componentsSeparatedByString:@"&amp;sound="][0];
-        downloadURL = [downloadURL stringByRemovingPercentEncoding];
+        downloadURL = [downloadURL stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
     }
 
     if ([downloadURL hasPrefix:@"http://imgur.com/download/gallery/"]) {


### PR DESCRIPTION
Replaces an instance of `-stringByRemovingPercentEncoding`, which is new in 10.9, with `-stringByReplacingPercentEscapesUsingEncoding:`.

Oh, and thanks for the app.
