### PR TITLE
Fixing a bug preventing starred thumbs from being saved.

### DIFF
--- a/objc/GIFs/gif_template.html
+++ b/objc/GIFs/gif_template.html
@@ -84,7 +84,7 @@
   <img src="{{OR_IMAGE_URL}}" />
 <footer>
   <h4>{{OR_IMAGE_URL}}</h4>
-  <a id='star' href="gifs-app:toggle-fav?dl={{OR_IMAGE_URL}}***thumb={{OR_THUMB_URL}}">&#9734</a>
+  <a id='star' href="gifs-app:toggle-fav?dl={{OR_IMAGE_URL}}***thumb={{OR_THUMB_URL}}&***source">&#9734</a>
 </footer>
 
 </body>


### PR DESCRIPTION
Currently my starred gifs don't show when I select them under the "starred" menu item. Best I can tell, not having `&***source` in the link in gif_template.html causes the thumbnail value to be nil in ORGIFController - https://github.com/orta/GIFs/blob/master/objc/GIFs/ORGIFController.m#L89. It also seems to cause `imageBrowserSelectionDidChange:` to cause an exception since the gif.imageRepresentation is nil.

I ran a few checks to make sure and thumbnails for new starred items seem to be working for me with this fix. I'm not sure what `&***source` is supposed to be so I'm just dropping that in with no value for now.
