### PR TITLE
Fix issue with copying gif url to clipboard

### DIFF
--- a/objc/GIFs/ORGIFRightClickMenuMaker.m
+++ b/objc/GIFs/ORGIFRightClickMenuMaker.m
@@ -139,7 +139,7 @@
 - (void)copyURL
 {
     [[NSPasteboard generalPasteboard] clearContents];
-    [[NSPasteboard generalPasteboard] writeObjects:@[self.gif.downloadURL]];
+    [[NSPasteboard generalPasteboard] writeObjects:@[self.gif.downloadURL.absoluteString]];
 }
 
 - (void)copyMarkdown


### PR DESCRIPTION
`BOOL test = [[NSPasteboard generalPasteboard] writeObjects:@[self.gif.downloadURL]];` is returning `YES` but the url can't be pasted later into a text editor. Going to *Finder > Edit > Show Clipboard* says the clipboard contents are unknown.

Seems like the system is writing the url as a plist?

```objc
NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
NSString *pasteboardValue = [pasteboard stringForType:NSURLPboardType];
NSLog(@"%@", pasteboardValue);
```
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<array>
	<string>http://i.imgur.com/k2gYqLG.gif</string>
	<string></string>
</array>
</plist>
```

Switching to write out the `absoluteString` of the url works for pasting.