### PR TITLE
Change the preview imageFrame to avoid the distortion

### DIFF
--- a/objc/GIFs/ORImageBrowserView.m
+++ b/objc/GIFs/ORImageBrowserView.m
@@ -23,7 +23,39 @@ static CGFloat const ORImageBrowserMargin = 3;
 
 - (NSRect)imageFrame
 {
-    return self.frame;
+    NSRect imageFrame = [super imageFrame];
+    
+    if (NSIsEmptyRect(imageFrame)) {
+        return NSZeroRect;
+    }
+    
+    CGFloat aspectRatio =  imageFrame.size.width / imageFrame.size.height;
+    
+    if (aspectRatio == 1.0f) {
+        return imageFrame;
+    }
+    
+    NSRect containerFrame = [self imageContainerFrame];
+    
+    if (NSIsEmptyRect(containerFrame)) {
+        return NSZeroRect;
+    }
+    
+    CGFloat containerAspectRatio = containerFrame.size.width / containerFrame.size.height;
+    
+    if (containerAspectRatio > aspectRatio) {
+        imageFrame.size.height = containerFrame.size.height;
+        imageFrame.origin.y = containerFrame.origin.y;
+        imageFrame.size.width = imageFrame.size.height * aspectRatio;
+        imageFrame.origin.x = containerFrame.origin.x + (containerFrame.size.width - imageFrame.size.width) / 2.0f;
+    } else {
+        imageFrame.size.width = containerFrame.size.width;
+        imageFrame.origin.x = containerFrame.origin.x;
+        imageFrame.size.height = imageFrame.size.width / aspectRatio;
+        imageFrame.origin.y = containerFrame.origin.y + (containerFrame.size.height - imageFrame.size.height) / 2.0f;
+    }
+    
+    return imageFrame;
 }
 
 - (NSRect) selectionFrame


### PR DESCRIPTION
Hi orta!!
I've tried to fix this annoying issue with the aspect ratio of the previews. I use the App everyday and being open source I thought that I could take some time and try to fix #30. 
Here is my result:

![captura de pantalla 2015-04-25 a las 19 14 58](https://cloud.githubusercontent.com/assets/750912/7334098/0dc76424-eb80-11e4-9b52-eeab3fe9cf53.png)

To be honest I was expecting something easy like changing the `UIImageView.contentMode` but I found this `IKImageBrowserView` in my way 🙈. Is the first time that I've work with this class so I don't know if there is a better way of doing it. 

![img_0033](https://cloud.githubusercontent.com/assets/750912/7334136/e534f0ce-eb81-11e4-9486-e870bf6be3c7.JPG)
